### PR TITLE
Calculate header checksum correctly, add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+ems-flasher

--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@
 #include "ems.h"
 
 // don't forget to bump this :P
-#define VERSION "0.04"
+#define VERSION "0.05"
 
 // one bank is 32 megabits
 #define BANK_SIZE 0x400000
@@ -212,6 +212,15 @@ mode_error2:
     usage(argv[0]);
 }
 
+uint8_t rom_checksum_header(unsigned char *rom)
+{
+        uint8_t checksum = 0;
+        for (uint16_t address = HEADER_TITLE; address < HEADER_CHKSUM; address++) {
+            checksum = checksum - rom[address] - 1;
+        }
+	return checksum;
+}
+
 /**
  * Main
  */
@@ -350,10 +359,7 @@ int main(int argc, char **argv) {
         }
 
         //Verify cartridge header checksum while we're at it
-        uint8_t calculated_chk = 0;
-        for (i = HEADER_TITLE; i < HEADER_CHKSUM; i++) {
-            calculated_chk -= buf[i] + 1;
-        }
+        uint8_t calculated_chk = rom_checksum_header(buf);
 
         if (calculated_chk != buf[HEADER_CHKSUM]) {
             printf("Cartridge header checksum invalid. This game will NOT boot on real hardware.\n");
@@ -418,10 +424,7 @@ int main(int argc, char **argv) {
         }
 
         //Verify cartridge header checksum while we're at it
-        calculated_chk = 0;
-        for (i = HEADER_TITLE; i < HEADER_CHKSUM; i++) {
-            calculated_chk -= buf[i] + 1;
-        }
+        calculated_chk = rom_checksum_header(buf);
 
         if (calculated_chk != buf[HEADER_CHKSUM]) {
             printf("Cartridge header checksum invalid. This game will NOT boot on real hardware.\n");


### PR DESCRIPTION
Two patches:

* Add a gitignore so git doesn't track objects/binary
* Finally fix the header checksum calculation which has never worked and was fixed incorrectly back in 2014